### PR TITLE
fix: correct grammar in model.py

### DIFF
--- a/gazelle/model.py
+++ b/gazelle/model.py
@@ -139,7 +139,7 @@ def positionalencoding2d(d_model, height, width):
         raise ValueError("Cannot use sin/cos positional encoding with "
                          "odd dimension (got dim={:d})".format(d_model))
     pe = torch.zeros(d_model, height, width)
-    # Each dimension use half of d_model
+    # Each dimension uses half of d_model
     d_model = int(d_model / 2)
     div_term = torch.exp(torch.arange(0., d_model, 2) *
                          -(math.log(10000.0) / d_model))


### PR DESCRIPTION
- Change "use" to "uses" to maintain proper subject-verb agreement ("each dimension" is singular, so it should be "uses").

- Note for reviewer: There is an existing mismatch between the error message mentioning “odd dimension” and the check `(d_model % 4 != 0)`. That check effectively requires d_model to be a multiple of 4, not merely “not odd.” Please review whether the error message should be updated for clarity.